### PR TITLE
Add initial Flask prototype for profile stock system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# test
+# Cam Balkon ve Profil Stok Sistemi
+
+Bu proje, marka bazlı cam balkon ve diğer profil serilerinin stok ve fiyat takibini yapmak için Python ve Flask kullanarak geliştirilmiş basit bir prototip içerir.
+
+## Özellikler
+
+- SQLite veritabanı kullanarak marka, seri, profil ve renk takibi
+- Excel/CSV formatındaki fiyat listelerini içe aktarma
+- Profil renklerine göre fiyat çarpanı belirleme
+- Basit web arayüzü üzerinden sipariş oluşturma ve fiyat hesaplama
+
+## Gereksinimler
+
+- Python 3.10+
+- `pip install -r requirements.txt`
+
+Uygulamayı başlatmak için:
+
+```bash
+python app.py
+```
+
+Uygulama varsayılan olarak `http://127.0.0.1:5000` adresinde çalışacaktır.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,74 @@
+from flask import Flask, render_template, request, redirect, url_for
+from models import db, Brand, Series, Profile, Color
+import pandas as pd
+
+app = Flask(__name__)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///data.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+db.init_app(app)
+
+
+@app.before_first_request
+def create_tables():
+    db.create_all()
+
+
+@app.route('/')
+def index():
+    brands = Brand.query.all()
+    return render_template('index.html', brands=brands)
+
+
+@app.route('/import', methods=['POST'])
+def import_prices():
+    file = request.files['file']
+    df = pd.read_excel(file)
+    for _, row in df.iterrows():
+        color = Color.query.filter_by(name=row['color']).first()
+        if not color:
+            color = Color(name=row['color'], multiplier=row.get('multiplier', 1.0))
+            db.session.add(color)
+        profile = Profile.query.filter_by(stock_code=row['stock_code']).first()
+        if not profile:
+            profile = Profile(
+                stock_code=row['stock_code'],
+                description=row['description'],
+                unit_price=row['unit_price'],
+                default_color=color,
+            )
+            db.session.add(profile)
+    db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/order', methods=['GET', 'POST'])
+def order():
+    profiles = Profile.query.all()
+    colors = Color.query.all()
+    if request.method == 'POST':
+        profile_id = int(request.form['profile'])
+        color_id = int(request.form['color'])
+        width = float(request.form['width'])
+        height = float(request.form['height'])
+        wing_count = int(request.form['wing_count'])
+
+        profile = Profile.query.get(profile_id)
+        color = Color.query.get(color_id)
+
+        perimeter = 2 * (width + height)
+        length = perimeter * wing_count
+        price = length * profile.unit_price * color.multiplier
+
+        return render_template(
+            'order_result.html',
+            profile=profile,
+            color=color,
+            length=length,
+            price=price,
+        )
+    return render_template('order.html', profiles=profiles, colors=colors)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,42 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+
+class Brand(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), unique=True, nullable=False)
+
+
+class Series(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(80), nullable=False)
+    brand_id = db.Column(db.Integer, db.ForeignKey('brand.id'), nullable=False)
+    brand = db.relationship('Brand', backref=db.backref('series', lazy=True))
+
+
+class Color(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(50), unique=True, nullable=False)
+    multiplier = db.Column(db.Float, default=1.0)
+
+
+series_profiles = db.Table(
+    'series_profiles',
+    db.Column('series_id', db.Integer, db.ForeignKey('series.id')),
+    db.Column('profile_id', db.Integer, db.ForeignKey('profile.id')),
+)
+
+
+class Profile(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    stock_code = db.Column(db.String(50), unique=True, nullable=False)
+    description = db.Column(db.String(200))
+    unit_price = db.Column(db.Float, nullable=False)
+    default_color_id = db.Column(db.Integer, db.ForeignKey('color.id'))
+    default_color = db.relationship('Color')
+    series = db.relationship(
+        'Series', secondary=series_profiles, backref=db.backref('profiles', lazy='dynamic')
+    )
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+Flask-SQLAlchemy
+pandas
+openpyxl

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>Profil Sistemi</title>
+<h1>Markalar</h1>
+<ul>
+{% for brand in brands %}
+  <li>{{ brand.name }}</li>
+{% endfor %}
+</ul>
+<form action="/import" method="post" enctype="multipart/form-data">
+  <p>Excel Fiyat Listesi: <input type="file" name="file"> <input type="submit" value="Yükle"></p>
+</form>
+<p><a href="/order">Sipariş Oluştur</a></p>

--- a/templates/order.html
+++ b/templates/order.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>Sipariş</title>
+<h1>Sipariş Oluştur</h1>
+<form method="post">
+  <p>Profil:
+    <select name="profile">
+      {% for p in profiles %}
+      <option value="{{ p.id }}">{{ p.description }}</option>
+      {% endfor %}
+    </select>
+  </p>
+  <p>Renk:
+    <select name="color">
+      {% for c in colors %}
+      <option value="{{ c.id }}">{{ c.name }}</option>
+      {% endfor %}
+    </select>
+  </p>
+  <p>Genişlik (m): <input type="number" step="0.01" name="width"></p>
+  <p>Yükseklik (m): <input type="number" step="0.01" name="height"></p>
+  <p>Kanat Sayısı: <input type="number" name="wing_count"></p>
+  <p><input type="submit" value="Hesapla"></p>
+</form>

--- a/templates/order_result.html
+++ b/templates/order_result.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Sipariş Sonucu</title>
+<h1>Sipariş Sonucu</h1>
+<p>Profil: {{ profile.description }}</p>
+<p>Renk: {{ color.name }}</p>
+<p>Toplam Uzunluk: {{ length }} m</p>
+<p>Fiyat: {{ price }} </p>
+<p><a href="/order">Yeni Sipariş</a></p>


### PR DESCRIPTION
## Summary
- create basic Flask application for profile inventory management
- add SQLAlchemy models for brands, series, profiles and colors
- enable importing price lists from Excel
- implement order form with width, height and wing count
- update README with setup instructions

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py models.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d6cd9e7c883279c00aca8d1f5e82b